### PR TITLE
boosts should be whole numbers

### DIFF
--- a/mods/dhssb/moves.js
+++ b/mods/dhssb/moves.js
@@ -338,9 +338,9 @@ exports.BattleMovedex = {
 		secondary: {
 			self: {
 				boosts: {
-					atk: 1.5,
+					atk: 1,
 					def: 2,
-					spe: 2.5,
+					spe: 3,
 				},
 			},
 		},
@@ -501,7 +501,7 @@ exports.BattleMovedex = {
 		self: {
 				boosts: {
 					atk: 3,
-					def: 1.5,
+					def: 1,
 					spe: 2,
 					spd: 1,
 				},


### PR DESCRIPTION
I think the non-integer boost was what created the glitch where Haxorus outsped Garchomp-Mega. Can't be 100% sure until it's updated, but it should be a whole number anyway.